### PR TITLE
Quality of life updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-scripts": "^5.0.1",
     "react-test-renderer": "^16.14.0",
     "reactstrap": "^8.4.1",
+    "scheduler": "^0.20.0",
     "typescript": "^4.7.4",
     "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"

--- a/template/src/index.css
+++ b/template/src/index.css
@@ -1,3 +1,15 @@
+/* Ensure the composite can spans the height of the screen by default */
+html,
+body,
+#root {
+  height: 100%
+}
+
+/* Hide the div element injected by FluentUI */
+.ui-provider {
+  height: 0;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/template/src/index.tsx
+++ b/template/src/index.tsx
@@ -7,8 +7,6 @@ import './index.css';
 import App from './App'; // this should point to your App.tsx file
 
 ReactDOM.render(
-  <div className="wrapper">
-    <App />
-  </div>,
+  <App />,
   document.getElementById('root')
 );


### PR DESCRIPTION
## What
* set document height to 100% so composites automatically fill the screen without setting their height
* hide the ui-provider element that fluent northstar injects
* remove unused wrapper div
* add scheduler dependency for older versions of react with newer versions of fluent