### PR TITLE
Fix template package dependencies & cleanup `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cra-template-communication-react",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "license": "MIT",
   "description": "Boilerplate set up to use Azure Communication Services UI Library.",
   "main": "template.json",
@@ -27,54 +27,5 @@
   "bugs": {
     "url": "https://github.com/Azure/communication-ui-library/issues"
   },
-  "homepage": "https://azure.github.io/communication-ui-library",
-  "dependencies": {
-    "@azure/communication-calling": "^1.9.1",
-    "@azure/communication-chat": "^1.3.0",
-    "@azure/communication-react": "^1.4.1",
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react-hooks": "^3.4.2",
-    "@testing-library/user-event": "^13.5.0",
-    "@types/jest": "^27.5.2",
-    "@types/node": "^16.11.49",
-    "@types/react": "^16.9.49",
-    "@types/react-dom": "^16.9.8",
-    "react": "~16.14.0",
-    "react-dom": "16.13.1",
-    "react-router-dom": "^5.1.2",
-    "react-scripts": "^5.0.1",
-    "react-test-renderer": "^16.14.0",
-    "reactstrap": "^8.4.1",
-    "scheduler": "^0.20.0",
-    "typescript": "^4.7.4",
-    "uuid": "^9.0.0",
-    "web-vitals": "^2.1.4"
-  },
-  "devDependencies": {
-    "@types/uuid": "^8.3.0"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+  "homepage": "https://azure.github.io/communication-ui-library"
 }

--- a/template.json
+++ b/template.json
@@ -17,6 +17,7 @@
             "react-scripts": "^5.0.1",
             "react-test-renderer": "^16.14.0",
             "reactstrap": "^8.4.1",
+            "scheduler": "^0.20.0",
             "typescript": "^4.7.4",
             "uuid": "^9.0.0",
             "web-vitals": "^2.1.4"


### PR DESCRIPTION
## What
* Move `package.json` dependency from #1 to `template.json`
* Remove unecessary `package.json` dependencies to avoid confusion
  * Remove other unecessary fields in the `package.json`
* But version to match next release

## Why
Incorrectly put the scheduler package in the package.json instead of the template.json in #1 

## How Tested

Did `npx create-react-app my-app --template file:...` locally and verified everything was working:

| project folder and package.json output | running app |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/2684369/211400583-78e9b834-9a52-4edf-b4cb-b026b22d7f0a.png) | ![image](https://user-images.githubusercontent.com/2684369/211400629-8dcdadbb-c72f-4a44-a117-b5845a40d2c7.png) |